### PR TITLE
Fix some general issues with Buoyant Objects (GerstnerWavesJobs.Registry Editor, physics-related)

### DIFF
--- a/Editor/BuoyantObjectEditor.cs
+++ b/Editor/BuoyantObjectEditor.cs
@@ -7,32 +7,38 @@ namespace WaterSystem.Physics
     [CustomEditor(typeof(BuoyantObject))]
     public class BuoyantObjectEditor : Editor
     {
-        private BuoyantObject obj;
+        private BuoyantObject Obj => serializedObject.targetObject as BuoyantObject;
+
         [SerializeField]
         private bool _heightsDebugBool;
+
         [SerializeField]
         private bool _generalSettingsBool;
 
-        private void OnEnable()
-        {
-            obj = serializedObject.targetObject as BuoyantObject;
-        }
-
         public override void OnInspectorGUI()
         {
-            _generalSettingsBool = EditorGUILayout.Foldout(_generalSettingsBool, "General Settings");
+            if (!EditorApplication.isPlaying)
+            {
+                base.OnInspectorGUI();
+                return;
+            }
+
+            _generalSettingsBool = EditorGUILayout.BeginFoldoutHeaderGroup(_generalSettingsBool, "General Settings");
+            EditorGUILayout.EndFoldoutHeaderGroup();
             if (_generalSettingsBool)
             {
                 base.OnInspectorGUI();
             }
 
-            if (EditorGUILayout.BeginFoldoutHeaderGroup(_heightsDebugBool, "Height Debug Values"))
+            _heightsDebugBool = EditorGUILayout.BeginFoldoutHeaderGroup(_heightsDebugBool, "Height Debug Values");
+            EditorGUILayout.EndFoldoutHeaderGroup();
+            if (_heightsDebugBool)
             {
-                if (obj.Heights != null)
+                if (Obj.Heights != null)
                 {
-                    for (var i = 0; i < obj.Heights.Length; i++)
+                    for (var i = 0; i < Obj.Heights.Length; i++)
                     {
-                        var h = obj.Heights[i];
+                        var h = Obj.Heights[i];
                         EditorGUILayout.LabelField($"{i})Wave(heights):", $"X:{h.x:00.00} Y:{h.y:00.00} Z:{h.z:00.00}");
                     }
                 }
@@ -41,7 +47,6 @@ namespace WaterSystem.Physics
                     EditorGUILayout.HelpBox("Height debug info only available in playmode.", MessageType.Info);
                 }
             }
-            EditorGUILayout.EndFoldoutHeaderGroup();
         }
     }
 }

--- a/Runtime/GerstnerWavesJobs.cs
+++ b/Runtime/GerstnerWavesJobs.cs
@@ -78,7 +78,9 @@ namespace WaterSystem
             _waterHeightHandle.Complete();
             
             DepthGenerator.CleanUp();
-            
+
+            Registry.Clear();
+
             //Cleanup native arrays
             _waveData.Dispose();
             _positions.Dispose();

--- a/Runtime/Materials/UnlitDebug.mat
+++ b/Runtime/Materials/UnlitDebug.mat
@@ -46,7 +46,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Depth:
-        m_Texture: {fileID: 2800000, guid: 37a375190af9a41f1b65c35d5829ad23, type: 3}
+        m_Texture: {fileID: 2800000, guid: 472408d18cae6ba43b335a55a1dcd445, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:

--- a/Runtime/Materials/UnlitDebug.mat
+++ b/Runtime/Materials/UnlitDebug.mat
@@ -46,7 +46,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Depth:
-        m_Texture: {fileID: 2800000, guid: 472408d18cae6ba43b335a55a1dcd445, type: 3}
+        m_Texture: {fileID: 2800000, guid: 37a375190af9a41f1b65c35d5829ad23, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:

--- a/Runtime/Physics/BuoyantObject.cs
+++ b/Runtime/Physics/BuoyantObject.cs
@@ -220,8 +220,10 @@ namespace WaterSystem.Physics
             {
                 LocalToWorldJob.Cleanup(_guid);
             }
-
-            _samplePoints.Dispose();
+            else
+            {
+                _samplePoints.Dispose();
+            }
         }
 
         private void LocalToWorldConversion()

--- a/Runtime/Physics/BuoyantObject.cs
+++ b/Runtime/Physics/BuoyantObject.cs
@@ -269,6 +269,7 @@ namespace WaterSystem.Physics
             var size = t.localScale;
             t.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
             t.localScale = Vector3.one;
+            UnityPhysics.SyncTransforms();
 
             _voxels = null;
             var points = new List<Vector3>();
@@ -305,6 +306,8 @@ namespace WaterSystem.Physics
             _voxels = points.ToArray();
 			t.SetPositionAndRotation(pos, rot);
             t.localScale = size;
+            UnityPhysics.SyncTransforms();
+
             var voxelVolume = Mathf.Pow(voxelResolution, 3f) * _voxels.Length;
             var rawVolume = rawBounds.size.x * rawBounds.size.y * rawBounds.size.z;
             volume = Mathf.Min(rawVolume, voxelVolume);


### PR DESCRIPTION
Fixes GerstnerWavesJobs.Registry to clear itself on CleanUp so changing Buoyant Object voxel resolution or buoyancy type doesn't require an Editor restart.

Fixed the following issues in the BuoyantObjectEditor:
- Inconsistent Foldout usage (using foldout headers rather than one of one and one of the other)
- Remove the concept of foldouts altogether if not in PLAYING mode, since Height Debug is only visible on PLAYING
- Make the Heights debug foldout actually openable by storing to the bool for it

Fixed the following issues in BuoyantObject:
- Explicit property types for IsVoxelBased and IsPhysicsBased so the code's easier to read for the different routes.
- Only do changes in `Update` if doing a NonPhysical type of interaction
- Only do changes in `FixedUpdate` if doing a Physical type of interaction, which makes the buoyant objects significantly less choppy when the frame rate is different to the fixed time step.
- Changed the `LateUpdate` call to a Coroutine-based `LateFixedUpdate` which runs AFTER the physics cycle has ran, whereas `FixedUpdate` runs before the physics.
- Call `Physics.SyncTransforms()` while slicing into voxels since we're explicitly changing transforms to reset to 0, but need them synced to actually query moved colliders.